### PR TITLE
Updated the archive removal so that it happens less frequently

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,15 +3,15 @@ name: Remove old artifacts
 on:
   schedule:
     # Every hour
-    - cron: '0,10,20,30,40,50 * * * *'
-
+    - cron: '15/30 * * * *'
+    
 jobs:
   remove-old-artifacts:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-
+    
     steps:
     - name: Remove old artifacts
       uses: c-hive/gha-remove-artifacts@v1
       with:
-        age: '10 seconds'
+        age: '10 minutes'


### PR DESCRIPTION
This makes it so that the artifact removals happen every 30 minutes, and the archives have to be at least 10 minutes old, so that it doesn't remove an artifact while the site is still building.